### PR TITLE
ci: Add CI with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI/CD
+
+on:
+  push:
+  pull_request:
+  # Run daily at 0:01 UTC
+  schedule:
+  - cron:  '1 0 * * *'
+
+jobs:
+  test:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        python -m pip install --ignore-installed --upgrade -q --no-cache-dir -e .[complete]
+        python -m pip list
+    - name: Test with pytest
+      run: |
+        python -m pytest -r sx

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # `dagger`: A Python Framework for Reproducible Machine Learning Experiment Orchestration
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+[![GitHub Actions Status: CI](https://github.com/facebookresearch/dagger/workflows/CI/CD/badge.svg)](https://github.com/facebookresearch/dagger/actions?query=workflow%3ACI%2FCD+branch%3Amaster)
 
 `dagger` is a framework to facilitate reproducible and reusable experiment orchestration in machine learning research.
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 
 extras_require = {
     "visualization": ["graphviz"],
-    "tests": ["pytest", "pytest-cov"],
+    "tests": ["cytoolz", "pytest", "pytest-cov"],
 }
 extras_require["complete"] = sorted(set(sum(extras_require.values(), [])))
 

--- a/setup.py
+++ b/setup.py
@@ -5,13 +5,16 @@
 
 from setuptools import setup, find_packages
 
+extras_require = {
+    "visualization": ["graphviz"],
+    "tests": ["pytest", "pytest-cov"],
+}
+extras_require["complete"] = sorted(set(sum(extras_require.values(), [])))
+
 setup(
     name="dagger",
     version="0.1.0",
     install_requires=["dill", "dask"],
     packages=find_packages(),
-    extras_require={
-        "visualization": ["graphviz"],
-        "tests": ["pytest", "pytest-cov"],
-    },
+    extras_require=extras_require,
 )


### PR DESCRIPTION
This PR adds CI using GitHub Actions. The workflow that is added runs the `pytest` test suite (yay for `pytest`!) on both [`push` events and `pull_request` events](https://help.github.com/en/actions/reference/events-that-trigger-workflows) on Linux and MacOS environments across the Python 3.x runtime spectrum. The CI will also run as a nightly CRON job at 0:01 UTC. The status of the CI on the `master` branch is reflected publicly by adding a status badge to the `README` (if viewed now it won't render as there haven't been any runs on FaceBook's project) that will look like the following:

[![GitHub Actions Status: CI](https://github.com/matthewfeickert/dagger/workflows/CI/CD/badge.svg)](https://github.com/matthewfeickert/dagger/actions)

To achieve this PR two changes are made to `setup.py` (one required and one suggested):
- The addition of `cytoolz` to the `tests` extra for the test suite to [not error as the result of `dask`](https://github.com/matthewfeickert/dagger/runs/532418333?check_suite_focus=true#step:5:13)
- The addition of a `complete` extra (with some rearrangement) which allows for installing the full environment with 
```
python -m pip install .[complete]
```
which is both easier for developers and for making sure the full environment works in CI.

```
* Add 'complete' extra for easier testing setup
* Add cytoolz to 'tests' extra
* Add CI with GitHub Actions
   - Add CI badge to README
```

Also, awesome to see this open sourced! Congratulations on doing so!
